### PR TITLE
Fix: TypeError {} is not iterable no heatmap

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -31,7 +31,9 @@ function Dashboard({ revLogs, sessions, exams, reviews, dueCount, onNotionSync, 
         if (total > 0) activity[dates[day.id]] = { done, total, pct: Math.round((done / total) * 100) };
       }
     }
-    if (agendaWeek && agendaWeek._weekKey) processWeek(agendaWeek, agendaWeek._weekKey);
+    const weekDays = agendaWeek?.days || (Array.isArray(agendaWeek) ? agendaWeek : null);
+    const weekKey = agendaWeek?._weekKey;
+    if (weekDays && weekKey) processWeek(weekDays, weekKey);
     (agendaHistory || []).forEach((entry) => { if (entry.days && entry.savedAt) processWeek(entry.days, entry.savedAt); });
     return activity;
   }, [agendaWeek, agendaHistory]);


### PR DESCRIPTION
## Summary
- Corrige crash "TypeError: {} is not iterable" ao abrir o app
- O formato da agenda no localStorage mudou para `{ _weekKey, _semana, days: [...] }` mas o heatmap tentava iterar o objeto diretamente
- Agora extrai `.days` antes de iterar, com fallback para formato antigo (array)

https://claude.ai/code/session_016dixCT7pN9LZ4S1J4VGv3S